### PR TITLE
Fix compiler warning by including unistd

### DIFF
--- a/demo.c
+++ b/demo.c
@@ -3,6 +3,7 @@
  */
 
 #include <stdio.h>
+#include <unistd.h>
 
 int main()
 {


### PR DESCRIPTION
Function sleep() is part of unistd so it should be explicitly included
to avoid compiler warning:

    implicit declaration of function ‘sleep’
    [-Wimplicit-function-declaration]